### PR TITLE
Exposed local end point on KcpClient/Server

### DIFF
--- a/kcp2k/kcp2k/highlevel/KcpClient.cs
+++ b/kcp2k/kcp2k/highlevel/KcpClient.cs
@@ -16,6 +16,9 @@ namespace kcp2k
         protected Socket socket;
         public EndPoint remoteEndPoint;
 
+        // The local end point of the client's socket
+        public EndPoint LocalEndPoint => socket == null ? null : socket.LocalEndPoint;
+
         // config
         protected readonly KcpConfig config;
 

--- a/kcp2k/kcp2k/highlevel/KcpServer.cs
+++ b/kcp2k/kcp2k/highlevel/KcpServer.cs
@@ -29,6 +29,9 @@ namespace kcp2k
         protected Socket socket;
         EndPoint newClientEP;
 
+        // The local end point of the server's socket.
+        public EndPoint LocalEndPoint => socket == null ? null : socket.LocalEndPoint;
+
         // raw receive buffer always needs to be of 'MTU' size, even if
         // MaxMessageSize is larger. kcp always sends in MTU segments and having
         // a buffer smaller than MTU would silently drop excess data.


### PR DESCRIPTION
This is useful for Noble Connect specifically, but also anyone else doing anything like port-forwarding, nat traversal, or relays.